### PR TITLE
Use latest Pronto

### DIFF
--- a/pronto-flay.gemspec
+++ b/pronto-flay.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'pronto', '~> 0.3.0'
+  s.add_dependency 'pronto', '~> 0.4.0'
   s.add_dependency 'flay', '~> 2.4.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This should probably be `~> 0.4`; the current gem depends on `~> 0.1.0`.