### PR TITLE
Fix NoMethodError in Pronto::Flay#patch_for_node

### DIFF
--- a/lib/pronto/flay.rb
+++ b/lib/pronto/flay.rb
@@ -38,7 +38,7 @@ module Pronto
 
     def patch_for_node(ruby_patches, node)
       ruby_patches.find do |patch|
-        patch.new_file_full_path.to_s == node.file.path
+        patch.new_file_full_path == node.file
       end
     end
 


### PR DESCRIPTION
`node.file` is no longer a File (it's a Pathname).