### PR TITLE
Add Mass To Message

### DIFF
--- a/lib/pronto/flay.rb
+++ b/lib/pronto/flay.rb
@@ -58,23 +58,23 @@ module Pronto
         "#{File.basename(node.file)}:#{node.line}"
       end
 
-      "#{match} code found in #{location.join(', ')}"
+      "#{match} code found in #{location.join(', ')} (mass = #{masses[hash]})"
     end
 
     def nodes_for(hash)
-      @flay.hashes[hash]
+      flay.hashes[hash]
     end
 
     def nodes
       result = []
-      masses.each do |mass|
-        nodes_for(mass.first).each { |node| result << node }
+      masses.keys.each do |hash|
+        nodes_for(hash).each { |node| result << node }
       end
       result
     end
 
     def masses
-      Array(@flay.masses)
+      flay.masses
     end
   end
 end

--- a/spec/pronto/flay_spec.rb
+++ b/spec/pronto/flay_spec.rb
@@ -25,7 +25,7 @@ module Pronto
 
         its(:count) { should == 1 }
         its(:'first.msg') do
-          should == 'Similar code found in hello.rb:6, hello.rb:12'
+          should == 'Similar code found in hello.rb:6, hello.rb:12 (mass = 32)'
         end
 
         context 'with ignored files' do


### PR DESCRIPTION
Feature:
Besides listing the similar files, add information about the mass score to the issue message.

Example:
```
app/models/post.rb:17 E: Identical code found in post.rb:5, post.rb:11, post.rb:17 (mass = 144)
```

Issue: https://github.com/mmozuras/pronto-flay/issues/8